### PR TITLE
Fix/versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "description": "Deployment package for the Pushcart library. To be used locally in conjunction with a Databricks environment remote, or in CI-CD",
     "keywords": [
-        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
         "Operating System :: OS Independent",
         "Topic :: Database :: Database Engines/Servers",
@@ -27,16 +27,14 @@
                                 "pyproject.toml"
                             ],
                             "from": "version = \".*\"",
-                            "to": "version = \"${nextRelease.version}\"",
-                            "results": [
-                                {
-                                    "file": "pyproject.toml",
-                                    "hasChanged": true,
-                                    "numMatches": 1,
-                                    "numReplacements": 1
-                                }
+                            "to": "version = \"${nextRelease.version}\""
+                        },
+                        {
+                            "files": [
+                                "src/pushcart_deploy/__init__.py"
                             ],
-                            "countMatches": true
+                            "from": "__VERSION__ = \".*\"",
+                            "to": "__VERSION__ = \"${nextRelease.version}\""
                         }
                     ]
                 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pushcart-deploy"
-version = "0.1.1"
+version = "0.1.2"
 description = "Deployment helper for pipeline configurations using Pushcart"
 authors = ["Georgel Preput <georgelpreput@mailbox.org>"]
 license = "GPL-3.0-or-later"

--- a/src/pushcart_deploy/__init__.py
+++ b/src/pushcart_deploy/__init__.py
@@ -1,3 +1,5 @@
 from .setup import Setup
 
 __all__ = ["configuration", "databricks-api", "validation", "Setup"]
+
+__VERSION__ = "0.1.1"

--- a/src/pushcart_deploy/__init__.py
+++ b/src/pushcart_deploy/__init__.py
@@ -2,4 +2,4 @@ from .setup import Setup
 
 __all__ = ["configuration", "databricks-api", "validation", "Setup"]
 
-__VERSION__ = "0.1.1"
+__VERSION__ = "0.1.2"


### PR DESCRIPTION
Validation kept failing for GitHub Actions @google/semantic-release-replace-plugin, so it's no longer done.