### PR TITLE
fix(core): Handle sql_query from .sql file

### DIFF
--- a/src/pushcart_deploy/configuration.py
+++ b/src/pushcart_deploy/configuration.py
@@ -70,6 +70,23 @@ async def get_transformations_from_csv(csv_path: Path | str) -> AsyncIterator[di
             yield row
 
 
+async def get_transformations_from_sql(sql_path: Path | str) -> str:
+    """Return transformations from SQL file.
+
+    Parameters
+    ----------
+    sql_path : Path | str
+        Path to an existing .sql file
+
+    Returns
+    -------
+    str
+        SQL string from input file
+    """
+    async with aiofiles.open(sql_path, "r") as sql_file:
+        return await sql_file.read()
+
+
 def expect_at_most_one_file(settings_path: Path | str) -> Path | None:
     """Check whether there is at most one configuration file for the given path.
 

--- a/src/pushcart_deploy/configuration.py
+++ b/src/pushcart_deploy/configuration.py
@@ -287,7 +287,7 @@ class Transformation:
 
     origin: constr(min_length=1, strict=True)
     target: constr(min_length=1, strict=True)
-    column_order: conint(ge=1) | None = None
+    column_order: conint(ge=1) | None = 1
     source_column_name: constr(strict=True) | None = None
     source_column_type: constr(
         strict=True,

--- a/src/pushcart_deploy/configuration.py
+++ b/src/pushcart_deploy/configuration.py
@@ -290,10 +290,16 @@ class Transformation:
     @classmethod
     def check_only_one_of_config_or_sql_query_defined(cls, values: dict) -> dict:
         """Check that one and only one of the config or sql_query fields is defined."""
-        if not any(values.get(v) is not None for v in ["column_order", "sql_query"]):
+        if not any(
+            values.get(v) is not None
+            for v in ["source_column_name", "dest_column_name", "sql_query"]
+        ):
             msg = f"No transformation defined. Please provide either a config or a sql_query.\nGot: {values}"
             raise ValueError(msg)
-        if all(values.get(t) for t in ["column_order", "sql_query"]):
+        if all(
+            values.get(t)
+            for t in ["source_column_name", "dest_column_name", "sql_query"]
+        ):
             msg = f"Only one of config or sql_query allowed.\nGot: {values}"
             raise ValueError(msg)
         return values

--- a/src/pushcart_deploy/metadata.py
+++ b/src/pushcart_deploy/metadata.py
@@ -136,11 +136,12 @@ class Metadata:
 
     @staticmethod
     async def _handle_sql_transformations(
-        transformation: dict, config_path: Path
+        transformation: dict,
+        config_path: Path,
     ) -> dict:
         sql_transformation = deepcopy(transformation)
         sql_transformation["sql_query"] = await get_transformations_from_sql(
-            config_path.resolve()
+            config_path.resolve(),
         )
 
         del sql_transformation["config"]
@@ -161,7 +162,7 @@ class Metadata:
                         enriched_transformations.append(row)
                 elif config_path.suffix == ".sql":
                     enriched_transformations.append(
-                        await self._handle_sql_transformations(t, config_path)
+                        await self._handle_sql_transformations(t, config_path),
                     )
                 else:
                     msg = "Transformation configurations can only be .csv or .sql files"

--- a/tests/data/pipelines/sample_catalog/sample_schema/sample_pipeline/example.sql
+++ b/tests/data/pipelines/sample_catalog/sample_schema/sample_pipeline/example.sql
@@ -1,0 +1,3 @@
+SELECT month, item_id, avg(price) AS average_price
+FROM vw__silver__item_cost
+GROUP BY item_id, month

--- a/tests/data/pipelines/sample_catalog/sample_schema/sample_pipeline/example.yaml
+++ b/tests/data/pipelines/sample_catalog/sample_schema/sample_pipeline/example.yaml
@@ -5,10 +5,7 @@ transformations:
 
   - origin: vw__silver__item_cost
     target: vw__silver__item_cost_monthly_avg
-    sql_query: |
-      SELECT month, item_id, avg(price) AS average_price
-      FROM vw__silver__item_cost
-      GROUP BY item_id, month
+    config: example.sql
 
   - origin: vw__silver__item_cost_monthly_avg
     target: vw__silver__item_cost_monthly_avg_summer

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -356,9 +356,9 @@ class TestTransformation:
                 sql_query="SELECT * FROM table",
             )
 
-    def test_transformation_with_both_config_and_sql_query_defined(self):
-        """Tests that a transformation with both config and sql query fields defined is
-        correctly validated.
+    def test_transformation_with_both_column_metadata_and_sql_query_defined(self):
+        """Tests that a transformation with both per-column metadata-driven transforms
+        and sql query fields defined is correctly validated.
         """
         with pytest.raises(ValueError):
             Transformation(
@@ -367,7 +367,8 @@ class TestTransformation:
                 pipeline_name="sample_pipeline",
                 origin="my_input_view",
                 target="my_output_view",
-                column_order=1,
+                source_column_name="input_column",
+                dest_column_name="output_column",
                 sql_query="SELECT * FROM table",
             )
 
@@ -398,7 +399,8 @@ class TestTransformation:
                 pipeline_name="sample_pipeline",
                 origin="my_input_view",
                 target="my_output_view",
-                column_order=1,
+                source_column_name="input_column",
+                dest_column_name="output_column",
                 validations=[validation1, validation2],
             )
         assert "Different actions for the same validation" in str(e.value)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -2,32 +2,9 @@ import asyncio
 from pathlib import PosixPath
 
 import pytest
-from pydantic.types import DirectoryPath
 
 from pushcart_deploy.configuration import Configuration
 from pushcart_deploy.metadata import Metadata
-
-"""
-Code Analysis
-
-Main functionalities:
-The Metadata class reads pipeline configuration files and creates backend objects in Databricks. It holds methods for reading, parsing, and enriching configuration files, then writing them to the Databricks environment into metadata tables: pushcart.sources, pushcart.transformations, pushcart.destinations.
-
-Methods:
-- `_load_pipeline_with_metadata(file_path: str) -> dict`: loads a pipeline configuration file into a dictionary and enriches it with metadata.
-- `_collect_pipeline_configs() -> list`: collects pipeline configuration files from the specified directory and returns them as a list.
-- `_enrich_sources_config(sources_config: list) -> None`: enriches the sources configuration with metadata.
-- `_enrich_transformations_config(transformations_config: list) -> None`: enriches the transformations configuration with metadata.
-- `_enrich_destinations_config(destinations_config: list) -> None`: enriches the destinations configuration with metadata.
-- `_enrich_pipeline_configs(pipeline_configs: list) -> None`: enriches the pipeline configurations with metadata.
-- `_group_pipeline_configs(pipeline_configs: list) -> list`: groups pipeline configurations by target schema and pipeline name.
-- `_validate_pipeline_configs(pipeline_configs: list) -> None`: validates pipeline configurations.
-- `_create_metadata_tables(pipeline_configs: list) -> None`: creates metadata tables holding pipeline stages.
-- `create_backend_objects() -> None`: creates metadata tables holding pipeline stages.
-
-Fields:
-- `config_dir: DirectoryPath`: the directory containing the pipeline configuration files.
-"""
 
 
 class TestMetadata:
@@ -63,9 +40,11 @@ class TestMetadata:
         """Tests that validated pipeline configurations are created successfully."""
         metadata = Metadata("./tests/data")
         pipeline_configs = asyncio.run(metadata._collect_pipeline_configs())
-        asyncio.run(metadata._enrich_pipeline_configs(pipeline_configs))
+        enriched_pipeline_configs = asyncio.run(
+            metadata._enrich_pipeline_configs(pipeline_configs)
+        )
         validated_pipeline_configs = metadata._validate_pipeline_configs(
-            pipeline_configs
+            enriched_pipeline_configs
         )
 
         assert isinstance(validated_pipeline_configs[0], Configuration)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -30,10 +30,15 @@ class TestMetadata:
 
         metadata = Metadata("./tests/data")
         pipeline_configs = await metadata._collect_pipeline_configs()
-        await metadata._enrich_pipeline_configs(pipeline_configs)
+        enriched_pipeline_configs = await metadata._enrich_pipeline_configs(
+            pipeline_configs
+        )
 
         assert any(
-            ["column_order" in t for t in pipeline_configs[0]["transformations"]]
+            [
+                "column_order" in t
+                for t in enriched_pipeline_configs[0]["transformations"]
+            ]
         )
 
     def test_validated_pipeline_configs_created_successfully(self):


### PR DESCRIPTION
Writing multiline SQL inside of a JSON configuration is nasty, so now there's support for adding a .sql file in the config field of a transformation.
Fixed missing column_order field for SQL transformations. Not a bug yet, but transformations will be sorted on column_order later.
Streamlined some code and made modifications for ease of maintainability.